### PR TITLE
Changed hyperlinks to rebranded jadice websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-This program show a possible adapter for how to use [_levigo®_](http://www.levigo.com) [_jadice server 5_](http://www.levigo.com/document-management/products/jadice-server/).
+This program show a possible adapter for how to use [_levigo_](https://solutions.levigo.com) [_jadice server 5_](https://jadice.com/index.php/de/uebersicht-51.html).
 
 It is provided "as is", see [LICENSE.md](https://github.com/levigo/jadice-server-converter-client/blob/master/LICENSE.md)
 
 ----
 
-Dieses Beispielprogramm zeigt eine mögliche Ansteuerung des [_levigo®_](http://www.levigo.de) [_jadice server 5_](http://www.levigo.de/dokumentenmanagement/produkte/jadice-server/).
+Dieses Beispielprogramm zeigt eine mögliche Ansteuerung des [_levigo®_](https://solutions.levigo.com) [_jadice server 5_](https://jadice.com/index.php/de/uebersicht-51.html).
 
 Es wird zur Verfügung gestellt "as is", siehe [LICENSE.md](https://github.com/levigo/jadice-server-converter-client/blob/master/LICENSE.md).
 

--- a/src/main/resources/about.html
+++ b/src/main/resources/about.html
@@ -9,12 +9,12 @@
 <h1>jadice server :: Converter Client</h1>
 
 <p>This is a demo application for 
-<a href="http://www.jadice.com/document-management/products/jadice-server/"> <em>levigo<sup>&reg;</sup> jadice server 5</em></a>.
+<a href="https://jadice.com/index.php/de/uebersicht-51.html"><em>jadice server 5</em></a>.
 You can either use it to trigger various conversion jobs or to monitor a remote instance of jadice server.</p>
 
 <p>For the latest version of this client visit <a href="https://github.com/levigo">our github site</a>. You are also welcome to fork the repository, make improvements and send us a pull request.</p>
 
-<p>If you are interested in a evaluation version of <em>levigo<sup>&reg;</sup> jadice server 5</em> or want get get more information about it, contact us at <a href="mailto:jadice-support@levigo.de">jadice-support@levigo.de</a>.</p>
+<p>If you are interested in a evaluation version of <em>jadice server 5</em> or want get get more information about it, contact us at <a href="mailto:jadice-support@levigo.de">jadice-support@levigo.de</a>.</p>
 
 <h2>Usage</h2>
 


### PR DESCRIPTION
The hyperlinks point to the URLs of the old levigo websites